### PR TITLE
Using shape instead of size to get number of rows

### DIFF
--- a/02 - Regression.ipynb
+++ b/02 - Regression.ipynb
@@ -323,7 +323,7 @@
     "# Split data 70%-30% into training set and test set\n",
     "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.30, random_state=0)\n",
     "\n",
-    "print ('Training Set: %d, rows\\nTest Set: %d rows' % (X_train.size, X_test.size))"
+    "print ('Training Set: %d, rows\\nTest Set: %d rows' % (X_train.shape[0], X_test.shape[0]))"
    ]
   },
   {


### PR DESCRIPTION
print ('Training Set: %d, rows\\nTest Set: %d rows' % (X_train.shape[0], X_test.shape[0]))