### PR TITLE
Update 05c - Transfer Learning (PyTorch).ipynb

### DIFF
--- a/05c - Transfer Learning (PyTorch).ipynb
+++ b/05c - Transfer Learning (PyTorch).ipynb
@@ -91,7 +91,7 @@
     "\n",
     "The pretrained model has many layers, starting with a convolutional layer that starts the feature extraction process from image data, and ending with a fully-connected linear layer that maps the extracted features to 1000 class labels.\n",
     "\n",
-    "For feature extraction to work with our own images, we  need to ensure that the image data we use the train our prediction layer has the same number of features (pixel values) as the images originally used to train the feaure extraction layers. The model does not explicitly give this size, but the first convolutional layer applies by a 7x7 kernel with a stride of 2x2 and results in 64 feature values, so the original size must be 64 x (7 &div; 2), which is 224.\n",
+    "For feature extraction to work with our own images, we  need to ensure that the image data we use to train our prediction layer has the same number of features (pixel values) as the images originally used to train the feaure extraction layers. The model does not explicitly give this size, but the first convolutional layer applies by a 7x7 kernel with a stride of 2x2 and results in 64 feature values, so the original size must be 64 x (7 &div; 2), which is 224.\n",
     "\n",
     "PyTorch includes functions for loading and transforming data. We'll use these to create an iterative loader for training data, and a second iterative loader for test data (which we'll use to validate the trained model). The loaders will transform the image data to match the format used to train the original resnet CNN model, convert the image data into *tensors* (which are the core data structure used in PyTorch), and normalize them.\n",
     "\n",


### PR DESCRIPTION
Fixed a typo from 'the' to 'to'