### PR TITLE
Update 05c - Transfer Learning (Tensorflow).ipynb

### DIFF
--- a/05c - Transfer Learning (Tensorflow).ipynb
+++ b/05c - Transfer Learning (Tensorflow).ipynb
@@ -83,7 +83,7 @@
     "\n",
     "The pretrained model has many layers, starting with a convolutional layer that starts the feature extraction process from image data.\n",
     "\n",
-    "For feature extraction to work with our own images, we  need to ensure that the image data we use the train our prediction layer has the same number of features (pixel values) as the images originally used to train the feature extraction layers, so we need data loaders for color images that are 224x224 pixels in size.\n",
+    "For feature extraction to work with our own images, we  need to ensure that the image data we use to train our prediction layer has the same number of features (pixel values) as the images originally used to train the feature extraction layers, so we need data loaders for color images that are 224x224 pixels in size.\n",
     "\n",
     "Tensorflow includes functions for loading and transforming data. We'll use these to create a generator for training data, and a second generator for test data (which we'll use to validate the trained model). The loaders will transform the image data to match the format used to train the original resnet CNN model and normalize them.\n",
     "\n",


### PR DESCRIPTION
Fixed typo in Transfer Learning (Tensorflow).ipynb from 'the' to 'to'.