### PR TITLE
Fix a typo in URL

### DIFF
--- a/challenges/02 - Real Estate Regression Challenge.ipynb
+++ b/challenges/02 - Real Estate Regression Challenge.ipynb
@@ -14,7 +14,7 @@
     ">\n",
     "> *Yeh, I. C., & Hsu, T. K. (2018). Building real estate valuation models with comparative approach through case-based reasoning. Applied Soft Computing, 65, 260-271.*\n",
     ">\n",
-    "> It was obtained from the UCI dataset repository (Dua, D. and Graff, C. (2019). [UCI Machine Learning Repository]([http://archive.ics.uci.edu/ml). Irvine, CA: University of California, School of Information and Computer Science).\n",
+    "> It was obtained from the UCI dataset repository (Dua, D. and Graff, C. (2019). [UCI Machine Learning Repository](http://archive.ics.uci.edu/ml). Irvine, CA: University of California, School of Information and Computer Science).\n",
     "\n",
     "## Review the data\n",
     "\n",


### PR DESCRIPTION
I deleted "[" from a markdown link, which was preventing it from working properly.