### PR TITLE
Update 05a - Deep Neural Networks (TensorFlow).ipynb

### DIFF
--- a/05a - Deep Neural Networks (TensorFlow).ipynb
+++ b/05a - Deep Neural Networks (TensorFlow).ipynb
@@ -41,7 +41,7 @@
     "# The dataset is too small to be useful for deep learning\r\n",
     "# So we'll oversample it to increase its size\r\n",
     "for i in range(1,3):\r\n",
-    "    penguins = penguins.append(penguins)\r\n",
+    "    penguins = pd.concat([penguins, penguins], ignore_index=True)\r\n",
     "\r\n",
     "# Display a random sample of 10 observations\r\n",
     "sample = penguins.sample(10)\r\n",


### PR DESCRIPTION
As of pandas 2.0, `append` (previously deprecated) was removed.

Replaced `append` with `concat`.