### PR TITLE
Fixed typo - Regression.ipynb

### DIFF
--- a/02 - Regression.ipynb
+++ b/02 - Regression.ipynb
@@ -621,7 +621,7 @@
     "# Train the model\n",
     "from sklearn.ensemble import GradientBoostingRegressor\n",
     "\n",
-    "# Fit a lasso model on the training set\n",
+    "# Fit a GradientBoostingRegressor model on the training set\n",
     "model = GradientBoostingRegressor().fit(X_train, y_train)\n",
     "print (model, \"\\n\")\n",
     "\n",


### PR DESCRIPTION
Fixed a typo in the Regression Exercise:
'Lasso' to 'GradientBoostingRegressor'